### PR TITLE
depend on ConstructionBase, drop 0.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ julia:
   - 1.1
   - nightly
 
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
   email: false
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "Flatten"
 uuid = "4c728ea3-d9ee-5c9a-9642-b6f7d7dc04fa"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 FieldMetadata = "bf96fef3-21d2-5d20-8afa-0e7d4c32a885"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - julia_version: 0.7
     - julia_version: 1.0
     - julia_version: latest
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ platform:
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)
-# matrix:
-  # allow_failures:
-    # - julia_version: nightly
+matrix:
+  allow_failures:
+    - julia_version: nightly
 
 branches:
   only:

--- a/src/Flatten.jl
+++ b/src/Flatten.jl
@@ -79,16 +79,11 @@ owes much to discussions and ideas from Jan Weidner (@jw3126) and Robin Deits.
 """
 module Flatten
 
-using ConstructionBase, FieldMetadata, Requires
+using ConstructionBase, FieldMetadata
 import FieldMetadata: @flattenable, @reflattenable, flattenable
 
 export @flattenable, @reflattenable, flattenable, flatten, reconstruct, update!, modify,
        metaflatten, fieldnameflatten, parentnameflatten, fieldtypeflatten, parenttypeflatten
-
-# Optionally load Unitful and unlittless falttening 
-function __init__()
-    @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" include("unitful.jl")
-end
 
 struct EmptyIgnore end
 

--- a/src/Flatten.jl
+++ b/src/Flatten.jl
@@ -79,7 +79,7 @@ owes much to discussions and ideas from Jan Weidner (@jw3126) and Robin Deits.
 """
 module Flatten
 
-using FieldMetadata, Requires
+using ConstructionBase, FieldMetadata, Requires
 import FieldMetadata: @flattenable, @reflattenable, flattenable
 
 export @flattenable, @reflattenable, flattenable, flatten, reconstruct, update!, modify,
@@ -103,15 +103,6 @@ nested(T::Type, expr_builder, expr_combiner, action) =
     nested(T, Nothing, expr_builder, expr_combiner, action)
 nested(T::Type, P::Type, expr_builder, expr_combiner, action) =
     expr_combiner(T, [Expr(:..., expr_builder(T, fn, action)) for fn in fieldnames(T)])
-
-
-"""
-    constructor_of(::Type)
-Add methods to define constructors for types with custom type parameters.
-"""
-@generated constructor_of(::Type{T}) where T = getfield(T.name.module, Symbol(T.name.name))
-constructor_of(::Type{T}) where T<:Tuple = tuple
-constructor_of(T::UnionAll) = constructor_of(T.body)
 
 
 """
@@ -272,7 +263,7 @@ reconstruct(x::U, data, ft::Function, use::Type{U}, ignore::Type{I}, n) where {U
 @generated reconstruct(obj, data, flattentrait::Function, use, ignore, n) = 
     quote
         args, n = $(reconstruct_inner(obj, reconstruct))
-        (constructor_of(typeof(obj))(args...),), n
+        (constructorof(typeof(obj))(args...),), n
     end
 
 _reconstruct(x, data) = data

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -3,4 +3,5 @@ using .Unitful
 struct QuantityConstructor{D,U} end
 QuantityConstructor{D,U}(x::T) where {T,D,U} = Quantity{T,D,U}(x)
 
-constructor_of(::Type{Quantity{T,D,U}}) where {T,D,U} = QuantityConstructor{D,U}
+ConstructionBase.constructorof(::Type{Quantity{T,D,U}}) where {T,D,U} = 
+    QuantityConstructor{D,U}

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -1,7 +1,0 @@
-using .Unitful
-
-struct QuantityConstructor{D,U} end
-QuantityConstructor{D,U}(x::T) where {T,D,U} = Quantity{T,D,U}(x)
-
-ConstructionBase.constructorof(::Type{Quantity{T,D,U}}) where {T,D,U} = 
-    QuantityConstructor{D,U}


### PR DESCRIPTION
This can't be merged yet - the Unitful code will be type pyracy with `constructor_of` moved to ConstructionBase. 

Unitful needs a ConstructionBase dep and `constructorof` for Quantity.