### PR TITLE
remove Tuple special-casing - its buggy

### DIFF
--- a/src/Flatten.jl
+++ b/src/Flatten.jl
@@ -354,10 +354,6 @@ metaflatten(obj, func::Function, ft::Function, use, ignore) =
 metaflatten(x::I, func::Function, ft::Function, use::Type{U}, ignore::Type{I}, P, fname) where {U,I} = ()
 metaflatten(x::U, func::Function, ft::Function, use::Type{U}, ignore::Type{I}, P, fname) where {U,I} =
     (func(P, fname),)
-# Better field names for tuples. TODO what about mixed type tuples?
-# Also this could be confusing, consider removing.
-metaflatten(xs::NTuple{N,Number}, func::Function, ft::Function, use, ignore, P, fname) where {N} =
-    map(x -> func(P, fname), xs)
 @generated metaflatten(obj, func::Function, flattentrait::Function, use, ignore, P, fname) =
     metaflatten_inner(obj)
 


### PR DESCRIPTION
This PR removes a hack in `metaflatten` that special cased tuples so that the parent type and parent field are those of the object the tuple is a field of.

It has a number of bugs - and is inconsistent. The field names of a tuple are the integers starting from 1 - and that is what `metaflatten`. Should use. Basically Tuples are no good for holding parameters using FieldMetadata.jl, and hacking to support them is a bad idea.

This is a breaking change to `metaflatten` behaviour when flattening `Tuple`