### PR TITLE
Make reconstruct type stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.vscode/
 docs/build
+Manifest.toml

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,9 +59,6 @@ nesttuple = Nest((foo, nest), 9, 10)
 foo2 = Foo(1, "two", :three)
 @test flatten(reconstruct(foo2, flatten(foo2, String, Real), String, Real), String, Real) == flatten(foo2, String, Real)
 
-tree = Flatten.buildtree(typeof(Foo(1.0,2.0,"abc")), :obj)
-reconstruct(Foo(1.0,2.0,"abc"), (10.0,5.0,"haha"))
-
 # Test `modify`
 @test modify(x -> 10x, foo) == Foo(10.0, 20.0, 30.0)
 @test modify(x -> x^2, nest, Int) == Nest(Foo(1,4,9), 4.0, 5.0f0)
@@ -169,7 +166,6 @@ mutable struct AnyPoint
 end
 anypoint = AnyPoint(1,2)
 @test flatten(anypoint) == (1,2)
-Flatten.buildtree(typeof(anypoint), :obj) |> typeof
 @test flatten(reconstruct(anypoint, (1,2))) == (1,2)
 
 # With void


### PR DESCRIPTION
This is intended to help address this downstream issue rafaqz/ModelParameters.jl#25 in `ModelParameters.jl` where `ModelParameters.update` loses type stability in nested structs. This appeared to be due to the (runtime) recursive call to the generated `reconstruct` function, which caused the compiler to just kind of "give up" on type inference.

This PR completely re-implements `reconstruct` by building a type tree at compile time in the `@generated _reconstruct` function and using the type information available at all levels of the tree to emit a recursion-free expression, where possible. In cases where field types are not known at compile time, the algorithm falls back to a runtime recursive call to `_reconstruct`.

I will apologize in advance for this code being terrible, ugly, and breaking pattern parity with the other functions (i.e. it no longer uses the `nested` builder/combiner pattern; I saw no clear way to reconcile this). In principle, you could re-implement the other methods using this pattern instead, but I don't see a good reason to do so unless we can identify the same type-stability issues (`flatten` seems to be reliably type stable; I have not tested `update` and `modify`).